### PR TITLE
enable onboard temperature register

### DIFF
--- a/src/adc.c
+++ b/src/adc.c
@@ -26,7 +26,7 @@ uint16_t adc_read_pin(uint8_t pin) {
     return adc_read() << 4;
 }
 
-uint16_t adc_read_temp(void) {
+int32_t adc_read_temp(void) {
     init();
     adc_set_temp_sensor_enabled(true);
     adc_select_input(4);

--- a/src/jd_user_config.h
+++ b/src/jd_user_config.h
@@ -45,4 +45,6 @@
 #define JD_I2C_HELPERS 1
 #define JD_HID 1
 
+#define JD_CONFIG_TEMPERATURE 1
+
 #endif


### PR DESCRIPTION
Looks like the adc_read_temp is implemented by the constant to enable it is missing.